### PR TITLE
Define the local stack specific configuration at config/test.exs

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ docker-compose up
 Then run the tests:
 
 ```
-AWS_ACCESS_KEY_ID='y' AWS_SECRET_ACCESS_KEY='x' MONITORING_HOST='localhost' MONITORING_SCHEME='http' MONITORING_PORT="4582"  mix test
+AWS_ACCESS_KEY_ID='y' AWS_SECRET_ACCESS_KEY='x' USE_LOCALSTACK=1 mix test
 ```
 
 ## License

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,8 +1,11 @@
 use Mix.Config
 
-{port, ""} = Integer.parse(System.get_env("MONITORING_PORT") || "443")
+if System.get_env("USE_LOCALSTACK") not in [nil, "", "0", "no"] do
 
-config :ex_aws, :monitoring,
-  scheme: System.get_env("MONITORING_SCHEME") || "https",
-  host: System.get_env("MONITORING_HOST") || "monitoring.us-east-1.amazonaws.com",
-  port: port
+  # see docker-compose.yml
+  # see https://github.com/localstack/localstack
+  config :ex_aws, :monitoring,
+         scheme: (if System.get_env("USE_SSL"), do: "https", else: "http"),
+         host: System.get_env("HOSTNAME") || "localhost",
+         port: 4582
+end


### PR DESCRIPTION
@cammellos 
The Integration test environment using LOCALSTACK you created is very nice and easy to use.

When setting up my environment variables according to `README.md`, I noticed that some values ​​could be defined in the `config/test.exs`.

If you like it, please merge this.
(this is experimental proposal, feel free to reject!)